### PR TITLE
Add accessibility labels to stars

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -148,11 +148,13 @@ class helper_plugin_starred extends DokuWiki_Plugin {
 
         if($dt){
             $result .= '<span title="'.$this->getLang('star_on').'" class="starred on">';
+            $result .= '<span class="a11y">' . $this->getLang('a11y_unstar_page') . '</span>';
             $result .= inlineSVG(__DIR__ . '/pix/star.svg');
             $result .= '</span>';
             //$result .= '<img src="'.DOKU_BASE.'lib/plugins/starred/pix/star.png" width="16" height="16" title="'.$this->getLang('star_on').'" alt="★" />';
         }else{
             $result .= '<span title="'.$this->getLang('star_off').'" class="starred off">';
+            $result .= '<span class="a11y">' . $this->getLang('a11y_star_page') . '</span>';
             $result .= inlineSVG(__DIR__ . '/pix/star-outline.svg');
             $result .= '</span>';
             //$result .= '<img src="'.DOKU_BASE.'lib/plugins/starred/pix/star_grey.png" width="16" height="16" title="'.$this->getLang('star_off').'" alt="☆" />';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -11,5 +11,7 @@ $lang['star_off'] = 'Not starred - click to star.';
 $lang['login']    = 'Please login to see your starred pages.';
 $lang['none']     = 'You currently have no starred pages.';
 $lang['e_nosqlite'] = 'The sqlite helper plugin could not be found.';
+$lang['a11y_star_page'] = 'Star this page.';
+$lang['a11y_unstar_page'] = 'Unstar this page.';
 
 //Setup VIM: ex: et ts=4 enc=utf-8 :


### PR DESCRIPTION
Not all screen readers read the title-attributes of elements. Hence add a hidden `span` to explain what purpose this link serves.